### PR TITLE
fix: add flush in java instruction

### DIFF
--- a/src/pages/getStarted/components/constants.ts
+++ b/src/pages/getStarted/components/constants.ts
@@ -25,9 +25,11 @@ export const getJavaCode = (sdkVersion: string, sdkKey: string, toggleKey: strin
 
     private static final FeatureProbe fpClient = new FeatureProbe("${sdkKey}", config);
 
-    public void test() {
+    public static void main(String[] args) throws InterruptedException {
         FPUser user = new FPUser("user_unique_id").with("userId", "9876").with("tel", "12345678998");
-        ${returnType === 'boolean' ? `boolean boolValue = featureProbe.boolValue("${toggleKey}", user, false);` : ''}${returnType === 'string' ? `String stringValue = featureProbe.stringValue("${toggleKey}", user, "Test");` : ''}${returnType === 'number' ? `double numberValue = featureProbe.numberValue("${toggleKey}", user, 500);` : ''}${returnType === 'json' ? `Map jsonValue = featureProbe.jsonValue("${toggleKey}", user, new HashMap(), Map.class);` : ''}
+        ${returnType === 'boolean' ? `boolean boolValue = fpClient.boolValue("${toggleKey}", user, false);` : ''}${returnType === 'string' ? `String stringValue = fpClient.stringValue("${toggleKey}", user, "Test");` : ''}${returnType === 'number' ? `double numberValue = fpClient.numberValue("${toggleKey}", user, 500);` : ''}${returnType === 'json' ? `Map jsonValue = fpClient.jsonValue("${toggleKey}", user, new HashMap(), Map.class);` : ''}
+        fpClient.flush();
+        Thread.sleep(1000);
     }
 }
 `


### PR DESCRIPTION
Java sdk `flush` (post access events) on fpClient constructed, and in a period of 5sec later, see DefaultEventProcessor.java#L68:
```java
scheduler.scheduleAtFixedRate(flusher, 0L, 5, TimeUnit.SECONDS);
```

Thus fpClient finished its first flush before taking the evaluation, but the program exits before its next flush job. In this case, server will never receive the access event, thus will always prompt user the sdk is not connected.